### PR TITLE
商品詳細表示機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, except: [:index]
+  before_action :authenticate_user!, except: [:index, :show]
 
   def index
     @items = Item.order(created_at: :desc)
@@ -16,6 +16,10 @@ class ItemsController < ApplicationController
     else
       render :new
     end
+  end
+
+  def show
+    @item = Item.find(params[:id])
   end
 
   private

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -122,9 +122,9 @@
       <% if @items.present? %>
         <% @items.each do |item| %>
           <li class='list'>
-            <%= link_to "#" do %>
+            <%= link_to item_path(item) do %>
             <div class='item-img-content'>
-              <%= image_tag item.image, class: "item-img", alt: "#{item.name} のimage No Image", onerror: "this.onerror=null;this.src='#{asset_path('noimage.png')}'" %>
+              <%= image_tag item.image, class: "item-img", alt: "No Image", onerror: "this.onerror=null;this.src='#{asset_path('noimage.png')}'" %>
 
               <%# 商品が売れていればsold outを表示しましょう %>
               <div class='sold-out'>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,13 +1,12 @@
 <%= render "shared/header" %>
 
-<%# 商品の概要 %>
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" , alt:"#{@item.name} のimage No Image", onerror: "this.onerror=null;this.src='#{asset_path('noimage.png')}'" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class="sold-out">
         <span>Sold Out!!</span>
@@ -16,54 +15,56 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        \ <%= @item.price %>
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.postage.name %>
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-    <p class="or-text">or</p>
-    <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
+    <% if user_signed_in? %>
+      <% if @item.user_id == current_user.id %>
+        <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+        <p class="or-text">or</p>
+        <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+      <% else %>
+        <%# 商品が売れていない場合はこちらを表示しましょう %>
+        <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+        <%# //商品が売れていない場合はこちらを表示しましょう %>
+      <% end %>
+    <% else %>
+      <%# 商品が売れていない場合はこちらを表示しましょう %>
+      <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+      <%# //商品が売れていない場合はこちらを表示しましょう %>
+    <% end %>
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.explanation %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.postage.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.sender.name %></td>
         </tr>
       </tbody>
     </table>
@@ -78,7 +79,6 @@
       </div>
     </div>
   </div>
-  <%# /商品の概要 %>
 
   <div class="comment-box">
     <form>
@@ -102,9 +102,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+  <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items, only: [:index, :new, :create] do
+  resources :items, only: [:index, :new, :create, :show] do
   end
 end


### PR DESCRIPTION
### **what**
・商品詳細表示機能の実装

### **why**
・商品一覧の情報をクリックすると該当の商品詳細ページへ遷移(未ログイン時も可)
・画像がリンク切れにならないようにダミー画像と「No Image」の文言を追加
・ログイン時、自身が出品した商品詳細画面では「商品の編集」「削除」をボタン表示
・ログイン時、他人が出品した商品詳細画面では「購入画面に進む」をボタン表示
・未ログイン時、商品詳細画面では「購入画面に進む」をボタン表示

### 実装後の挙動
ログイン状態且つ、自身が出品した販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/5c2611de424d99288a356c6e5e4f7950

ログイン状態且つ、自身が出品していない販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/cb5e3ed5cf087e0fc203aa2bc415c8f7

ログアウト状態で、商品詳細ページへ遷移した動画
https://gyazo.com/95c0765010a175f527ce911c2d769d5d