### PR TITLE
商品購入機能の実装_モデル単体のテストコード作成

### DIFF
--- a/ER図.dio
+++ b/ER図.dio
@@ -1,6 +1,6 @@
 <mxfile host="65bd71144e">
     <diagram id="dVOWez3NV2Hg3_Ec22Ul" name="ページ1">
-        <mxGraphModel dx="84" dy="229" grid="1" gridSize="10" guides="1" tooltips="1" connect="0" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
+        <mxGraphModel dx="265" dy="792" grid="1" gridSize="10" guides="1" tooltips="1" connect="0" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
             <root>
                 <mxCell id="0"/>
                 <mxCell id="1" parent="0"/>
@@ -136,7 +136,7 @@
                         <mxRectangle width="140" height="30" as="alternateBounds"/>
                     </mxGeometry>
                 </mxCell>
-                <mxCell id="93" value="destinations Table(購入)" style="shape=table;startSize=30;container=1;collapsible=0;childLayout=tableLayout;fixedRows=1;rowLines=0;fontStyle=1;" parent="1" vertex="1">
+                <mxCell id="93" value="orders Table(購入)" style="shape=table;startSize=30;container=1;collapsible=0;childLayout=tableLayout;fixedRows=1;rowLines=0;fontStyle=1;" parent="1" vertex="1">
                     <mxGeometry x="310" y="190" width="180" height="120" as="geometry"/>
                 </mxCell>
                 <mxCell id="94" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;top=0;left=0;bottom=0;right=0;collapsible=0;dropTarget=0;fillColor=none;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;" parent="93" vertex="1">
@@ -347,13 +347,13 @@
                         <mxRectangle width="40" height="30" as="alternateBounds"/>
                     </mxGeometry>
                 </mxCell>
-                <mxCell id="174" value="" style="endArrow=ERone;html=1;strokeWidth=1;startSize=8;endSize=8;targetPerimeterSpacing=7;jumpSize=11;endFill=0;startArrow=ERone;startFill=0;sourcePerimeterSpacing=7;entryX=-0.003;entryY=0.647;entryDx=0;entryDy=0;exitX=1;exitY=0.666;exitDx=0;exitDy=0;exitPerimeter=0;entryPerimeter=0;" parent="1" target="84" edge="1" source="94">
+                <mxCell id="174" value="" style="endArrow=ERone;html=1;strokeWidth=1;startSize=8;endSize=8;targetPerimeterSpacing=7;jumpSize=11;endFill=0;startArrow=ERone;startFill=0;sourcePerimeterSpacing=7;entryX=-0.003;entryY=0.647;entryDx=0;entryDy=0;exitX=1;exitY=0.666;exitDx=0;exitDy=0;exitPerimeter=0;entryPerimeter=0;" parent="1" source="94" target="84" edge="1">
                     <mxGeometry width="50" height="50" relative="1" as="geometry">
                         <mxPoint x="530" y="410" as="sourcePoint"/>
                         <mxPoint x="529.83" y="520" as="targetPoint"/>
                     </mxGeometry>
                 </mxCell>
-                <mxCell id="176" value="destination" style="shape=partialRectangle;html=1;whiteSpace=wrap;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;overflow=hidden;" parent="1" vertex="1">
+                <mxCell id="176" value="order" style="shape=partialRectangle;html=1;whiteSpace=wrap;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;overflow=hidden;" parent="1" vertex="1">
                     <mxGeometry x="620" y="400" width="140" height="30" as="geometry">
                         <mxRectangle width="140" height="30" as="alternateBounds"/>
                     </mxGeometry>
@@ -368,7 +368,7 @@
                         <mxRectangle width="140" height="30" as="alternateBounds"/>
                     </mxGeometry>
                 </mxCell>
-                <mxCell id="179" value="" style="edgeStyle=elbowEdgeStyle;elbow=vertical;endArrow=ERone;html=1;curved=0;rounded=0;endSize=8;startSize=8;exitX=0.882;exitY=-0.001;exitDx=0;exitDy=0;exitPerimeter=0;startArrow=ERone;startFill=0;endFill=0;entryX=0.228;entryY=1.133;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" parent="1" source="73" target="100">
+                <mxCell id="179" value="" style="edgeStyle=elbowEdgeStyle;elbow=vertical;endArrow=ERone;html=1;curved=0;rounded=0;endSize=8;startSize=8;exitX=0.882;exitY=-0.001;exitDx=0;exitDy=0;exitPerimeter=0;startArrow=ERone;startFill=0;endFill=0;entryX=0.228;entryY=1.133;entryDx=0;entryDy=0;entryPerimeter=0;" parent="1" source="73" target="100" edge="1">
                     <mxGeometry width="50" height="50" relative="1" as="geometry">
                         <mxPoint x="210" y="360" as="sourcePoint"/>
                         <mxPoint x="350" y="340" as="targetPoint"/>

--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ group :development, :test do
   gem 'factory_bot_rails'
   gem 'faker'
   gem 'gimei'
+  gem 'pry-rails'
 end
 
 group :development do
@@ -66,3 +67,4 @@ end
 gem 'mini_magick'
 gem 'image_processing', '~> 1.2'
 gem 'active_hash'
+gem 'payjp'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,7 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     childprocess (4.1.0)
+    coderay (1.1.3)
     concurrent-ruby (1.2.2)
     crass (1.0.6)
     date (3.3.3)
@@ -87,6 +88,8 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.5.0)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
     erubi (1.12.0)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
@@ -100,6 +103,9 @@ GEM
       romaji
     globalid (1.1.0)
       activesupport (>= 5.0)
+    http-accept (1.7.0)
+    http-cookie (1.0.5)
+      domain_name (~> 0.5)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     image_processing (1.12.2)
@@ -124,6 +130,9 @@ GEM
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
+    mime-types (3.4.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2023.0218.1)
     mini_magick (4.12.0)
     mini_mime (1.1.2)
     mini_portile2 (2.8.1)
@@ -139,6 +148,7 @@ GEM
       timeout
     net-smtp (0.3.3)
       net-protocol
+    netrc (0.11.0)
     nio4r (2.5.9)
     nokogiri (1.13.10)
       mini_portile2 (~> 2.8.0)
@@ -149,7 +159,14 @@ GEM
     parallel (1.23.0)
     parser (3.2.2.0)
       ast (~> 2.4.1)
+    payjp (0.0.10)
+      rest-client (~> 2.0)
     pg (1.4.6)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     public_suffix (5.0.1)
     puma (4.3.12)
       nio4r (~> 2.0)
@@ -194,6 +211,11 @@ GEM
     responders (3.1.0)
       actionpack (>= 5.2)
       railties (>= 5.2)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rexml (3.2.5)
     romaji (0.2.4)
       rake (>= 0.8.0)
@@ -265,6 +287,9 @@ GEM
     turbolinks-source (5.2.0)
     tzinfo (1.2.11)
       thread_safe (~> 0.1)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.8.2)
     unicode-display_width (2.4.2)
     warden (1.2.9)
       rack (>= 2.0.9)
@@ -306,7 +331,9 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   mini_magick
   mysql2 (>= 0.5.3)
+  payjp
   pg
+  pry-rails
   puma (~> 4.1)
   rails (~> 6.0.3, >= 6.0.3.4)
   rspec-rails

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 ### Association
 
 - has_many :items
-- has_many :destinations
+- has_many :orders
 
 ## items テーブル
 
@@ -34,10 +34,10 @@
 
 ### Association
 
-- has_one :destination
+- has_one :order
 - belongs_to :user
 
-## destinations テーブル
+## orders テーブル
 
 | Column        | Type       | Options                        |
 | ------------- | ---------- | ------------------------------ |
@@ -60,8 +60,8 @@
 | address        | string     | null: false,                   |
 | building       | string     |                                |
 | phone_number   | string     | null: false,                   |
-| destination    | references | null: false, foreign_key: true |
+| order          | references | null: false, foreign_key: true |
 
 ### Association
 
-- belongs_to :destination
+- belongs_to :order

--- a/app/assets/stylesheets/orders/index.css
+++ b/app/assets/stylesheets/orders/index.css
@@ -105,26 +105,6 @@
   margin: 5px 5px;
 }
 
-.input-expiration-date-wrap {
-  width: 100%;
-  display: flex;
-  text-align: center;
-  line-height: 55px;
-}
-
-.input-expiration-date {
-  width: 20%;
-  margin-top: 5px;
-  height: 48px;
-  border-radius: 4px;
-  border: 1px solid #ccc;
-  background: #fff;
-  font-size: 16px;
-  resize: none;
-  line-height: 45px;
-  text-align: center;
-}
-
 /* /カード情報の入力 */
 
 /* 配送先の入力 */

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
   before_action :set_item, only: [:show, :edit, :update, :destroy]
   before_action :check_owner, only: [:edit, :update, :destroy]
+  before_action :check_order, only: [:edit, :update, :destroy]
 
   def index
     @items = Item.order(created_at: :desc)
@@ -51,6 +52,12 @@ class ItemsController < ApplicationController
 
   def check_owner
     unless @item.user_id == current_user.id
+      redirect_to root_path
+    end
+  end
+
+  def check_order
+    if @item.order.present? || @item.user_id == current_user.id
       redirect_to root_path
     end
   end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,0 +1,55 @@
+class OrdersController < ApplicationController
+  before_action :authenticate_user!, except: :index
+  before_action :set_item, only: [:index, :create]
+  before_action :check_owner, only: [:index, :create]
+  before_action :check_order, only: [:index, :create]
+  
+
+  def index
+    @order = OrderAddress.new
+  end
+
+  def create
+    @order = OrderAddress.new(order_address_params)
+    if @order.valid?
+      pay_item
+      @order.save
+      redirect_to root_path
+    else
+      render "orders/index"
+    end
+  end
+
+  private
+
+  def set_item
+    @item = Item.find(params[:item_id])
+  end
+
+  def check_owner
+    unless user_signed_in?
+      redirect_to new_user_session_path
+      return
+    end
+  end
+
+  def check_order
+    if @item.order.present? || @item.user_id == current_user.id
+      redirect_to root_path
+    end
+  end
+
+  def order_address_params
+    params.require(:order_address).permit(:post_code, :prefecture_id, :municipality, :address, :building, :phone_number).merge(user_id: current_user.id, item_id: params[:item_id], token: params[:token])
+  end
+
+  def pay_item
+    set_item
+    Payjp.api_key = ENV["PAYJP_SECRET_KEY"]
+    Payjp::Charge.create(
+      amount: set_item[:price],
+      card: order_address_params[:token],
+      currency:'jpy'
+    )
+  end
+end

--- a/app/helpers/orders_helper.rb
+++ b/app/helpers/orders_helper.rb
@@ -1,0 +1,2 @@
+module OrdersHelper
+end

--- a/app/javascript/card.js
+++ b/app/javascript/card.js
@@ -1,0 +1,32 @@
+const pay = () => {
+  const payjp = Payjp(process.env.PAYJP_PUBLIC_KEY);
+  const elements = payjp.elements();
+  const numberElement = elements.create('cardNumber');
+  const expiryElement = elements.create('cardExpiry');
+  const cvcElement = elements.create('cardCvc');
+
+  numberElement.mount('#card-number');
+  expiryElement.mount('#card-exp');
+  cvcElement.mount('#card-cvc');
+
+  const submit = document.getElementById("button");
+
+  submit.addEventListener("click", (e) => {
+    e.preventDefault();
+    payjp.createToken(numberElement).then(function (response) {
+      if (response.error) {
+      } else {
+        const token = response.id;
+        const renderDom = document.getElementById("charge-form");
+        const tokenObj = `<input value=${token} type="hidden" name='token'>`;
+        renderDom.insertAdjacentHTML("beforeend", tokenObj);
+      }
+      numberElement.clear();
+      expiryElement.clear();
+      cvcElement.clear();
+      document.getElementById("charge-form").submit();
+    });
+  });
+};
+
+window.addEventListener("load", pay);

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -7,6 +7,7 @@ require("@rails/ujs").start()
 // require("turbolinks").start()
 require("@rails/activestorage").start()
 require("channels")
+require("../card")
 
 
 // Uncomment to copy all static images under ../images to the output folder and reference

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,0 +1,6 @@
+class Address < ApplicationRecord
+  extend ActiveHash::Associations::ActiveRecordExtensions
+  
+  belongs_to :order
+  belongs_to :prefecture
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -18,5 +18,5 @@ class Item < ApplicationRecord
   belongs_to :sender
   belongs_to :user
   has_one_attached :image
+  has_one :order
 end
-

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,0 +1,5 @@
+class Order < ApplicationRecord
+  belongs_to :user
+  belongs_to :item
+  has_one :address
+end

--- a/app/models/order_address.rb
+++ b/app/models/order_address.rb
@@ -4,12 +4,17 @@ class OrderAddress
   include ActiveModel::Model
   attr_accessor :token, :user_id, :item_id, :post_code, :prefecture_id, :municipality, :address, :building, :phone_number
 
-  validates :token,         presence: true
-  validates :post_code,     presence: true, format: { with: /\A\d{3}[-]\d{4}\z/, message:"is invalid. Enter it as follows (e.g. 123-4567)"}
-  validates :prefecture_id, presence: true, numericality: { other_than: 1, message: "is invalid" }
-  validates :municipality,  presence: true
-  validates :address,       presence: true
-  validates :phone_number,  presence: true, format: { with: /\A\d{10,11}\z/, message: "is invalid. Input only number" }, length: { minimum: 10, message: "is too short" }
+  with_options presence: true do
+    validates :user_id
+    validates :item_id
+    validates :token
+    validates :post_code,     format: { with: /\A\d{3}[-]\d{4}\z/, message:"is invalid. Enter it as follows (e.g. 123-4567)"}
+    validates :prefecture_id, numericality: { other_than: 1, message: "is invalid" }
+    validates :municipality
+    validates :address
+    validates :phone_number, format: { with: /\A\d{10,11}\z/, message: "is invalid. Input only number" }, length: { minimum: 10, message: "is too short" }
+  end
+
   def save
     order = Order.create(user_id: user_id, item_id: item_id)
     Address.create(post_code: post_code, prefecture_id: prefecture_id, municipality: municipality, address: address, building: building, phone_number: phone_number, order_id: order.id)

--- a/app/models/order_address.rb
+++ b/app/models/order_address.rb
@@ -1,0 +1,17 @@
+class OrderAddress
+  extend ActiveHash::Associations::ActiveRecordExtensions
+
+  include ActiveModel::Model
+  attr_accessor :token, :user_id, :item_id, :post_code, :prefecture_id, :municipality, :address, :building, :phone_number
+
+  validates :token,         presence: true
+  validates :post_code,     presence: true, format: { with: /\A\d{3}[-]\d{4}\z/, message:"is invalid. Enter it as follows (e.g. 123-4567)"}
+  validates :prefecture_id, presence: true, numericality: { other_than: 1, message: "is invalid" }
+  validates :municipality,  presence: true
+  validates :address,       presence: true
+  validates :phone_number,  presence: true, format: { with: /\A\d{10,11}\z/, message: "is invalid. Input only number" }, length: { minimum: 10, message: "is too short" }
+  def save
+    order = Order.create(user_id: user_id, item_id: item_id)
+    Address.create(post_code: post_code, prefecture_id: prefecture_id, municipality: municipality, address: address, building: building, phone_number: phone_number, order_id: order.id)
+  end
+end

--- a/app/models/prefecture.rb
+++ b/app/models/prefecture.rb
@@ -51,6 +51,7 @@ class Prefecture < ActiveHash::Base
   ]
   include ActiveHash::Associations
   has_many :items
+  has_many :addresses
 
 end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,5 +19,5 @@ class User < ApplicationRecord
   validates :password, format: { with: /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]{6,}\z/i, message: "is invalid. Include both letters and numbers" }
 
   has_many :items
-  # has_many :destinations
+  has_many :orders
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,11 +126,11 @@
             <div class='item-img-content'>
               <%= image_tag item.image, class: "item-img", alt: "No Image", onerror: "this.onerror=null;this.src='#{asset_path('noimage.png')}'" %>
 
-              <%# 商品が売れていればsold outを表示しましょう %>
-              <div class='sold-out'>
-                <span>Sold Out!!</span>
-              </div>
-              <%# //商品が売れていればsold outを表示しましょう %>
+              <% if item.order.present? %>
+                <div class='sold-out'>
+                  <span>Sold Out!!</span>
+                </div>
+              <% end %>
 
             </div>
             <div class='item-info'>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -7,11 +7,11 @@
     </h2>
     <div class="item-img-content">
       <%= image_tag @item.image ,class:"item-box-img" , alt:"#{@item.name} のimage No Image", onerror: "this.onerror=null;this.src='#{asset_path('noimage.png')}'" %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class="sold-out">
-        <span>Sold Out!!</span>
-      </div>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
+      <% if @item.order.present? %>
+        <div class="sold-out">
+          <span>Sold Out!!</span>
+        </div>
+      <% end %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
@@ -23,19 +23,19 @@
     </div>
 
     <% if user_signed_in? %>
-      <% if @item.user_id == current_user.id %>
-        <%= link_to "商品の編集", edit_item_path, method: :get, class: "item-red-btn" %>
-        <p class="or-text">or</p>
-        <%= link_to "削除", item_path(@item.id), method: :delete, class:"item-destroy" %>
-      <% else %>
-        <%# 商品が売れていない場合はこちらを表示しましょう %>
-        <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-        <%# //商品が売れていない場合はこちらを表示しましょう %>
+      <% unless @item.order.present? %>
+        <% if @item.user_id == current_user.id %>
+          <%= link_to "商品の編集", edit_item_path, method: :get, class: "item-red-btn" %>
+          <p class="or-text">or</p>
+          <%= link_to "削除", item_path(@item.id), method: :delete, class:"item-destroy" %>
+        <% else %>
+          <%= link_to "購入画面に進む", item_orders_path(item_id: @item.id, action: :index), class: "item-red-btn" %>
+        <% end %>
       <% end %>
     <% else %>
-      <%# 商品が売れていない場合はこちらを表示しましょう %>
-      <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-      <%# //商品が売れていない場合はこちらを表示しましょう %>
+      <% unless @item.order.present? %>
+        <%= link_to "購入画面に進む", item_orders_path(@item), method: :get, class: "item-red-btn" %>
+      <% end %>
     <% end %>
     <div class="item-explain-box">
       <span><%= @item.explanation %></span>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,9 +4,9 @@
     <title>Furima39212</title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
-
-    <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
-    <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
+    <script type="text/javascript" src="https://js.pay.jp/v2/pay.js"></script>
+    <%= stylesheet_link_tag 'application', media: 'all'  %>
+    <%= javascript_pack_tag 'application' %>
   </head>
 
   <body>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -1,0 +1,120 @@
+<%= render "shared/second-header"%>
+
+<div class='transaction-contents'>
+  <div class='transaction-main'>
+    <h1 class='transaction-title-text'>
+      購入内容の確認
+    </h1>
+    <div class='buy-item-info'>
+      <%= image_tag @item.image, class: 'buy-item-img' %>
+      <div class='buy-item-right-content'>
+        <h2 class='buy-item-text'>
+          <%= @item.name %>
+        </h2>
+        <div class='buy-item-price'>
+          <p class='item-price-text'>¥<%= @item.price %></p>
+          <p class='item-price-sub-text'><%= @item.postage.name %></p>
+        </div>
+      </div>
+    </div>
+
+    <div class='item-payment'>
+      <h1 class='item-payment-title'>
+        支払金額
+      </h1>
+      <p class='item-payment-price'>
+        ¥<%= @item.price %>
+      </p>
+    </div>
+
+    <%= form_with model: @order, url: item_orders_path, id: 'charge-form', class: 'transaction-form-wrap', local: true do |f| %>
+    <%= render 'shared/error_messages', model: @order, f: f %>
+
+    <div class='credit-card-form'>
+      <h1 class='info-input-haedline'>
+        クレジットカード情報入力
+      </h1>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">カード情報</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <div id="card-number" class="input-default" ></div>
+        <div class='available-card'>
+          <%= image_tag 'card-visa.gif', class: 'card-logo'%>
+          <%= image_tag 'card-mastercard.gif', class: 'card-logo'%>
+          <%= image_tag 'card-jcb.gif', class: 'card-logo'%>
+          <%= image_tag 'card-amex.gif', class: 'card-logo'%>
+        </div>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">有効期限</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <div id="card-exp" class="input-default" ></div>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">セキュリティコード</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <div id="card-cvc" class="input-default" ></div>
+      </div>
+    </div>
+
+    <div class='shipping-address-form'>
+      <h1 class='info-input-haedline'>
+        配送先入力
+      </h1>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">郵便番号</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.text_field :post_code, class:"input-default", id:"postal-code", placeholder:"例）123-4567", maxlength:"8" %>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">都道府県</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"prefecture"}) %>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">市区町村</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.text_field :municipality, class:"input-default", id:"city", placeholder:"例）横浜市緑区"%>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">番地</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.text_field :address, class:"input-default", id:"addresses", placeholder:"例）青山1-1-1"%>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">建物名</label>
+          <span class="form-any">任意</span>
+        </div>
+        <%= f.text_field :building, class:"input-default", id:"building", placeholder:"例）柳ビル103"%>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">電話番号</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.text_field :phone_number, class:"input-default", id:"phone-number", placeholder:"例）09012345678",maxlength:"11"%>
+      </div>
+    </div>
+
+    <div class='buy-btn'>
+      <%= f.submit "購入" ,class:"buy-red-btn", id:"button" %>
+    </div>
+    <% end %>
+  </div>
+</div>
+<%= render "shared/second-footer"%>

--- a/app/views/orders/index.html.erbZone.Identifier
+++ b/app/views/orders/index.html.erbZone.Identifier
@@ -1,0 +1,3 @@
+[ZoneTransfer]
+ZoneId=3
+ReferrerUrl=E:\techcamp\4.download\furima_ëfçﬁ.zip

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -29,7 +29,7 @@ Rails.application.configure do
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false
-
+  config.active_job.queue_adapter = :inline
   # Store uploaded files on the local file system in a temporary directory.
   config.active_storage.service = :test
 

--- a/config/initializers/webpacker.rb
+++ b/config/initializers/webpacker.rb
@@ -1,0 +1,1 @@
+Webpacker::Compiler.env["PAYJP_PUBLIC_KEY"] = ENV["PAYJP_PUBLIC_KEY"]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,6 @@ Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
   resources :items do
+    resources :orders, only: [:index, :create]
   end
 end

--- a/db/migrate/20230503123026_create_orders.rb
+++ b/db/migrate/20230503123026_create_orders.rb
@@ -1,0 +1,9 @@
+class CreateOrders < ActiveRecord::Migration[6.0]
+  def change
+    create_table :orders do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :item, null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230503123357_create_addresses.rb
+++ b/db/migrate/20230503123357_create_addresses.rb
@@ -1,0 +1,14 @@
+class CreateAddresses < ActiveRecord::Migration[6.0]
+  def change
+    create_table :addresses do |t|
+      t.string     :post_code,     null: false
+      t.integer    :prefecture_id, null: false
+      t.string     :municipality,  null: false
+      t.string     :address,       null: false
+      t.string     :building
+      t.string     :phone_number,  null: false
+      t.references :order,         null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_04_28_080458) do
+ActiveRecord::Schema.define(version: 2023_05_03_123357) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "name", null: false
@@ -33,6 +33,19 @@ ActiveRecord::Schema.define(version: 2023_04_28_080458) do
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
+  create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.string "post_code", null: false
+    t.integer "prefecture_id", null: false
+    t.string "municipality", null: false
+    t.string "address", null: false
+    t.string "building"
+    t.string "phone_number", null: false
+    t.bigint "order_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["order_id"], name: "index_addresses_on_order_id"
+  end
+
   create_table "items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "name", null: false
     t.integer "category_id", null: false
@@ -46,6 +59,15 @@ ActiveRecord::Schema.define(version: 2023_04_28_080458) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["user_id"], name: "index_items_on_user_id"
+  end
+
+  create_table "orders", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "item_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["item_id"], name: "index_orders_on_item_id"
+    t.index ["user_id"], name: "index_orders_on_user_id"
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
@@ -67,5 +89,8 @@ ActiveRecord::Schema.define(version: 2023_04_28_080458) do
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "addresses", "orders"
   add_foreign_key "items", "users"
+  add_foreign_key "orders", "items"
+  add_foreign_key "orders", "users"
 end

--- a/spec/factories/order_address.rb
+++ b/spec/factories/order_address.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :order_address do
+    token         {"tok_abcdefghijk00000000000000000"}
+    post_code     { "123-4567" }
+    prefecture_id { 2 }
+    municipality  { "函館市" }
+    address       { "花園町24番2号" }
+    phone_number  { "09000000000" }
+    building      { "テストビル" }
+  end
+end

--- a/spec/factories/order_address.rb
+++ b/spec/factories/order_address.rb
@@ -1,5 +1,7 @@
 FactoryBot.define do
   factory :order_address do
+    user_id       {1}
+    item_id       {1}
     token         {"tok_abcdefghijk00000000000000000"}
     post_code     { "123-4567" }
     prefecture_id { 2 }

--- a/spec/factories/order_address.rb
+++ b/spec/factories/order_address.rb
@@ -1,7 +1,5 @@
 FactoryBot.define do
   factory :order_address do
-    user_id       {1}
-    item_id       {1}
     token         {"tok_abcdefghijk00000000000000000"}
     post_code     { "123-4567" }
     prefecture_id { 2 }

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
    end
     nickname              { Faker::Name.name}
     email                 { Faker::Internet.free_email}
-    password              { Faker::Internet.password(min_length: 6, mix_case: true) }
+    password              { 'Abc123' }
     password_confirmation { password }
     family_name           { person.last.kanji }
     given_name            { person.first.kanji }

--- a/spec/helpers/destinations_helper_spec.rb
+++ b/spec/helpers/destinations_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the DestinationsHelper. For example:
+#
+# describe DestinationsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe DestinationsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/order_addresses_spec.rb
+++ b/spec/models/order_addresses_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe OrderAddress, type: :model do
     before do
       user = FactoryBot.create(:user)
       item = FactoryBot.create(:item)
-      @order_address = FactoryBot.build(:order_address)
+      @order_address = FactoryBot.build(:order_address, user_id: user.id, item_id: item.id)
     end
 
     context '正常系' do

--- a/spec/models/order_addresses_spec.rb
+++ b/spec/models/order_addresses_spec.rb
@@ -1,0 +1,92 @@
+require 'rails_helper'
+
+RSpec.describe OrderAddress, type: :model do
+  before do
+    @order_address = FactoryBot.build(:order_address)
+  end
+
+  describe '商品の購入' do
+    context '正常系' do
+      it 'token、post_code、prefecture_id、municipality、address、phone_numberが存在すれば購入できる' do
+        expect(@order_address).to be_valid
+      end
+
+      it 'buildingは空でも購入できる' do
+        @order_address.building =''
+        expect(@order_address).to be_valid
+      end
+    end
+
+    context '異常系' do
+      it 'tokenが空だと購入できない' do
+        @order_address.token = ''
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Token can't be blank")
+      end
+
+      it 'post_codeが空だと購入できない' do
+        @order_address.post_code = ''
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Post code can't be blank", "Post code is invalid. Enter it as follows (e.g. 123-4567)")
+      end
+
+      it 'prefecture_idが空だと購入できない' do
+        @order_address.prefecture_id = ''
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Prefecture can't be blank")
+      end
+
+      it 'municipalityが空だと購入できない' do
+        @order_address.municipality = ''
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Municipality can't be blank")
+      end
+
+      it 'addressが空だと購入できない' do
+        @order_address.address = ''
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Address can't be blank")
+      end
+
+      it 'phone_numberが空だと購入できない' do
+        @order_address.phone_number = ''
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Phone number can't be blank", "Phone number is invalid. Input only number", "Phone number is too short")
+      end
+      
+      it 'post_codeは3桁(-)4桁の数字でないと購入できない' do
+        @order_address.post_code = '1234-123' , '123-456a'
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Post code is invalid. Enter it as follows (e.g. 123-4567)")
+      end
+
+      it 'prefecture_idが"1"では購入できない' do
+        @order_address.prefecture_id = '1'
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Prefecture is invalid")
+      end
+
+      it 'phone_numberが10桁以下では購入できない' do
+        @order_address.phone_number = '123456789'
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Phone number is too short")
+      end
+
+      it 'phone_numberが10桁もしくは11桁の数字でないと購入できない' do
+        @order_address.phone_number = '123456789a','1234567890a'
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Phone number is invalid. Input only number")
+      end
+
+      it 'itemが紐づいていなければ購入できない' do
+        @order_address.item_id = nil
+        @order_address.valid?
+      end
+
+      it 'ユーザーが紐付いていなければ購入できない' do
+        @order_address.user_id = nil
+        @order_address.valid?
+      end
+    end
+  end
+end

--- a/spec/models/order_addresses_spec.rb
+++ b/spec/models/order_addresses_spec.rb
@@ -1,13 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe OrderAddress, type: :model do
-  before do
-    @order_address = FactoryBot.build(:order_address)
-  end
-
   describe '商品の購入' do
+    before do
+      user = FactoryBot.create(:user)
+      item = FactoryBot.create(:item)
+      @order_address = FactoryBot.build(:order_address)
+    end
+
     context '正常系' do
-      it 'token、post_code、prefecture_id、municipality、address、phone_numberが存在すれば購入できる' do
+      it 'user_id、item_id、token、post_code、prefecture_id、municipality、address、phone_numberが存在すれば購入できる' do
         expect(@order_address).to be_valid
       end
 
@@ -18,6 +20,18 @@ RSpec.describe OrderAddress, type: :model do
     end
 
     context '異常系' do
+      it 'user_idが空だと購入できない' do
+        @order_address.user_id = ''
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("User can't be blank")
+      end
+
+      it 'item_idが空だと購入できない' do
+        @order_address.item_id = ''
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Item can't be blank")
+      end
+
       it 'tokenが空だと購入できない' do
         @order_address.token = ''
         @order_address.valid?

--- a/spec/requests/destinations_spec.rb
+++ b/spec/requests/destinations_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Destinations", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end


### PR DESCRIPTION
### **what**
・商品購入機能の実装
・order_addressモデル単体のテストコードの作成

### **why**
・ログインしたユーザーが他社の出品された商品を購入するため
・orderテーブル、addressテーブルを作成し、orders/index.html.erbから2つのテーブルへ保存するためFormオブジェクトパターンを用いてorder_addressテーブルを作成。
・クレジット決済処理のため、card.jsを作成(PAY.JPにて決済処理を確認済み)
・order_addressテーブルのバリデーションに対するテストコードを作成し、問題がないことを確認済み

※ビューに合わせてER図とREADMEを変更しました
　変更箇所：destination → order へ変更
ER図： https://gyazo.com/da1ed3fb303ddd207a6f2c4467bacdb8

### 実装後の挙動
 必要な情報を適切に入力して「購入」ボタンを押すと、商品の購入ができる動画
https://gyazo.com/706ff966f6b4206a0e9c281098b0fc00

 入力に問題がある状態で「購入」ボタンが押された場合、情報は受け入れられず、購入ページでエラーメッセージが表示される動画
https://gyazo.com/64c3f6ed674718bb6485b3a7b98af7b9

 ログイン状態の場合でも、URLを直接入力して自身が出品していない売却済み商品の商品購入ページへ遷移しようとすると、トップページに遷移する動画
https://gyazo.com/560dc8256a628cd8a0650a45d29fbec3

 ログイン状態の場合でも、URLを直接入力して自身が出品した商品の商品購入ページに遷移しようとすると、商品の販売状況に関わらずトップページに遷移する動画
https://gyazo.com/a5470963bea4e8f74b42c4b98c342a24

 ログアウト状態の場合は、URLを直接入力して商品購入ページに遷移しようとすると、商品の販売状況に関わらずログインページに遷移する動画
購入前： https://gyazo.com/070e2ec7749c6fbcde7eef1e9e13644c
売却済： https://gyazo.com/dbc8fcf7e762044837ee88394806f7e0

 売却済みの商品は、画像上に「sold out」の文字が表示される動画
 売却済みの商品は、画像上に「sold out」の文字が表示される動画
https://gyazo.com/53778ee663d62db75713e78a7bb99884

 ログイン状態の場合でも、売却済みの商品には、「商品の編集」「削除」「購入画面に進む」ボタンが表示されない動画
https://gyazo.com/4034d99b77b483d2cc63c73350d1decf

 ログイン状態の場合でも、URLを直接入力して自身が出品した売却済み商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画
https://gyazo.com/f4a26eadf780ac25686901d53c11df08

 テスト結果の画像
https://gyazo.com/3b53386ac58c448446a227683b1edfec